### PR TITLE
Add support for light switch devices

### DIFF
--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -114,7 +114,7 @@ class Environment(object):
         elif usn.startswith('uuid:Sensor'):
             klass = Motion
         else:
-            log.info("Unrecognized device type. USN={0}.format(usn))
+            log.info("Unrecognized device type. USN={0}".format(usn))
             return
         device = klass(headers['location'])
         self._process_device(device)


### PR DESCRIPTION
ouimeaux-0.3 didn't work with the WeMo light switch device that I just installed. I did a bit of debugging and discovered that the light switch identifies itself differently than the socket switch. The USN header in the SSDP response from my light switch looked like `USN: uuid:Lightswitch-1_0-...` but it seems like the interface for turning it one and off is the same as the socket switch, so the `ouimeaux.Switch` class works to control it. Applying this diff enables ouimeaux to turn on and off my light switch. Hopefully you can accept this diff into your project. Thanks for writing ouimeaux!

Cheers,

Nathan
