### PR TITLE
Adding basic instructions for installation on Debian/Ubuntu.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,21 @@ find and download the binary installers for these packages here:
 - gevent: https://github.com/SiteSupport/gevent/downloads
 - greenlet: https://pypi.python.org/pypi/greenlet
 
+Debian/Ubuntu
+-------------
+The ouimeaux setup.py script uses python's easy_install, and the python
+header files.  You can use apt-get to install these.
+
+    sudo apt-get install python-setuptools python-dev
+
+Once these are installed, you should be able to easily build and install.
+
+    sudo python setup.py install
+
+You will likely need to explicitly set the --bind port to the wemo script.
+Use `ifconfig` to determine your IP address, then launch with, e.g.
+
+    wemo --bind 10.0.1.6:54321 list
 
 Changelog
 ~~~~~~~~~


### PR DESCRIPTION
I've added some basic instructions for satisfying dependencies that setup.py needs, which some debian installs don't include.  And I've added a note on invoking with --bind, which debian also seems to need.
