### PR TITLE
Wemo Maker CLI Functions

### DIFF
--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -105,7 +105,13 @@ Usage: wemo maker NAME (on|off|toggle|sensor)"""
         matches = matcher(device_name)
     else:
         matches = NOOP
+        
+    def on_switch(maker):
+        return
 
+    def on_motion(maker):
+        return
+        
     def on_maker(maker):
         if matches(maker.name):
             if state == "toggle":
@@ -127,7 +133,7 @@ Usage: wemo maker NAME (on|off|toggle|sensor)"""
                 getattr(maker, state)()
             sys.exit(0)
             
-    scan(args, on_maker)
+    scan(args, on_switch, on_motion, on_maker)
     # If we got here, we didn't find anything
     print "No device found with that name."
     sys.exit(1)

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -22,9 +22,9 @@ def _state(device, readable=False):
         return state
 
 
-def scan(args, on_switch=NOOP, on_motion=NOOP):
+def scan(args, on_switch=NOOP, on_motion=NOOP, on_maker=NOOP):
     try:
-        env = Environment(on_switch, on_motion, with_subscribers=False,
+        env = Environment(on_switch, on_motion, on_maker, with_subscribers=False,
                           bind=args.bind, with_cache=args.use_cache)
         env.start()
         with get_cache() as c:
@@ -91,8 +91,11 @@ def list_(args):
 
     def on_motion(motion):
         print "Motion:", motion.name
+        
+    def on_maker(maker):
+        print "Maker:", maker.name
 
-    scan(args, on_switch, on_motion)
+    scan(args, on_switch, on_motion, on_maker)
 
 
 def status(args):
@@ -102,8 +105,11 @@ def status(args):
 
     def on_motion(motion):
         print "Motion:", motion.name, '\t', _state(motion, args.human_readable)
+        
+    def on_maker(maker):
+        print "Maker:", maker.name, '\t', _state(maker, args.human_readable)
 
-    scan(args, on_switch, on_motion)
+    scan(args, on_switch, on_motion, on_maker)
 
 
 def clear(args):

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -108,7 +108,8 @@ def status(args):
         
     def on_maker(maker):
         print "Maker:", maker.name, '\t', "Switch State:", _state(maker, args.human_readable)
-        print '\t', "Sensor State:", maker.sensorstate
+        if maker.has_sensor:
+             print '\t', '\t', '\t', "Sensor:", maker.sensor_state
 
     scan(args, on_switch, on_motion, on_maker)
 

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -126,7 +126,7 @@ Usage: wemo maker NAME (on|off|toggle|sensor)"""
             else:
                 getattr(maker, state)()
             sys.exit(0)
-
+            
     scan(args, on_maker)
     # If we got here, we didn't find anything
     print "No device found with that name."
@@ -250,8 +250,7 @@ def wemo():
     makerparser = subparser.add_parser("maker", 
                                        help="Get sensor state of a Maker or Turn on or off")
     makerparser.add_argument("device", help="Name or alias of the device")
-    makerparser.add_argument("sensor", help="Return the sensor state")
-    makerparser.add_argument("state", help="'on' or 'off' or 'toggle'")
+    makerparser.add_argument("state", help="'on' or 'off' or 'toggle' or 'sensor'")
     makerparser.set_defaults(func=maker)
 
     listparser = subparsers.add_parser("list",

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -92,9 +92,11 @@ def maker(args):
         state = "toggle"
     elif args.state.lower() == "sensor":
         state = "sensor"
+    elif args.state.lower() == "switch":
+        state = "switch"
     else:
         print """No valid action specified. 
-Usage: wemo maker NAME (on|off|toggle|sensor)"""
+Usage: wemo maker NAME (on|off|toggle|sensor|switch)"""
         sys.exit(1)
 
     device_name = args.device
@@ -129,6 +131,11 @@ Usage: wemo maker NAME (on|off|toggle|sensor)"""
                           print maker.sensor_state
                 else:
                      print "Sensor not present"
+            elif state == "switch":
+                 if maker.switch_mode:
+                      print "Momentary Switch" 
+                 else:
+                      print _state(maker, args.human_readable)
             else:
                 getattr(maker, state)()
             sys.exit(0)
@@ -254,9 +261,9 @@ def wemo():
     stateparser.set_defaults(func=switch)
     
     makerparser = subparsers.add_parser("maker", 
-                                       help="Get sensor state of a Maker or Turn on or off")
+                                       help="Get sensor or switch state of a Maker or Turn on or off")
     makerparser.add_argument("device", help="Name or alias of the device")
-    makerparser.add_argument("state", help="'on' or 'off' or 'toggle' or 'sensor'")
+    makerparser.add_argument("state", help="'on' or 'off' or 'toggle' or 'sensor' or 'switch'")
     makerparser.set_defaults(func=maker)
 
     listparser = subparsers.add_parser("list",

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -107,7 +107,8 @@ def status(args):
         print "Motion:", motion.name, '\t', _state(motion, args.human_readable)
         
     def on_maker(maker):
-        print "Maker:", maker.name, '\t', _state(maker, args.human_readable)
+        print "Maker:", maker.name, '\t', "Switch State:", _state(maker, args.human_readable)
+        print '\t', "Sensor State:", maker.sensorstate
 
     scan(args, on_switch, on_motion, on_maker)
 

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -107,10 +107,21 @@ def status(args):
         print "Motion:", motion.name, '\t', _state(motion, args.human_readable)
         
     def on_maker(maker):
-        print maker.switch_mode
-        print "Maker:", maker.name, '\t', "State:", state(maker, args.human_readable)
+        if maker.switch_mode:
+             print "Maker:", maker.name, '\t', "Momentary State:", _state(maker, args.human_readable) 
+        else:
+             print "Maker:", maker.name, '\t', "Persistent State:", _state(maker, args.human_readable)
         if maker.has_sensor:
-             print '\t', '\t', '\t', "Sensor:", maker.sensor_state
+             if args.human_readable:
+                  if maker.sensor_state:
+                       sensorstate = 'On'
+                  else:
+                       sensorstate = 'Off'
+                  print '\t\t\t', "Sensor:", sensorstate
+             else:
+                  print '\t\t\t', "Sensor:", maker.sensor_state
+        else:
+             print '\t\t\t' "Sensor not present"
 
     scan(args, on_switch, on_motion, on_maker)
 

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -247,7 +247,7 @@ def wemo():
     stateparser.add_argument("state", help="'on' or 'off")
     stateparser.set_defaults(func=switch)
     
-    makerparser = subparser.add_parser("maker", 
+    makerparser = subparsers.add_parser("maker", 
                                        help="Get sensor state of a Maker or Turn on or off")
     makerparser.add_argument("device", help="Name or alias of the device")
     makerparser.add_argument("state", help="'on' or 'off' or 'toggle' or 'sensor'")

--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -107,7 +107,8 @@ def status(args):
         print "Motion:", motion.name, '\t', _state(motion, args.human_readable)
         
     def on_maker(maker):
-        print "Maker:", maker.name, '\t', "Switch State:", _state(maker, args.human_readable)
+        print maker.switch_mode
+        print "Maker:", maker.name, '\t', "State:", state(maker, args.human_readable)
         if maker.has_sensor:
              print '\t', '\t', '\t', "Sensor:", maker.sensor_state
 

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from .switch import Switch
+from ouimeaux.device import Device
 from xml.etree import cElementTree as et
 
 
-class Maker(Switch):
+class Maker(Device):
 
     def __repr__(self):
         return '<WeMo Maker "{name}">'.format(name=self.name)

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -35,7 +35,7 @@ class Maker(Device):
         makerresp = makerresp.replace("&lt;","<")
         attributes = et.fromstring(makerresp)
         for attribute in attributes:
-            elif attribute[0].text == "Sensor":
+            if attribute[0].text == "Sensor":
             	sensorstate = attribute[1].text
             elif attribute[0].text == "SwitchMode":
             	switchmode = attribute[1].text

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -7,6 +7,25 @@ class Maker(Device):
 
     def __repr__(self):
         return '<WeMo Maker "{name}">'.format(name=self.name)
+        
+    def set_state(self, state):
+        """
+        Set the state of this device to on or off.
+        """
+        self.basicevent.SetBinaryState(BinaryState=int(state))
+        self._state = int(state)
+
+    def off(self):
+        """
+        Turn this device off. If already off, will return "Error".
+        """
+        return self.set_state(0)
+
+    def on(self):
+        """
+        Turn this device on. If already on, will return "Error".
+        """
+        return self.set_state(1)
 
     @property
     def maker_attribs(self):
@@ -16,16 +35,13 @@ class Maker(Device):
         makerresp = makerresp.replace("&lt;","<")
         attributes = et.fromstring(makerresp)
         for attribute in attributes:
-            if attribute[0].text == "Switch":
-            	state = attribute[1].text
             elif attribute[0].text == "Sensor":
             	sensorstate = attribute[1].text
             elif attribute[0].text == "SwitchMode":
             	switchmode = attribute[1].text
             elif attribute[0].text == "SensorPresent":
             	hassensor = attribute[1].text
-        return { 'state' : state,
-        		 'sensorstate' : int(sensorstate),
+        return { 'sensorstate' : int(sensorstate),
         		 'switchmode' : int(switchmode),
         		 'hassensor' : int(hassensor)}
 

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from .switch import Switch
 from ouimeaux.device import Device
 from xml.etree import cElementTree as et
 

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -144,15 +144,15 @@ class Environment(object):
         self._process_device(device)
 
     def _process_device(self, device, cache=None):
-        if isinstance(device, Switch):
+        if isinstance(device, Maker):
+            callback = self._maker_callback
+            registry = self._makers
+        elif isinstance(device, Switch):
             callback = self._switch_callback
             registry = self._switches
         elif isinstance(device, Motion):
             callback = self._motion_callback
             registry = self._motions
-        elif isinstance(device, Maker):
-        	callback = self._maker_callback
-        	registry = self._makers
         else:
             return
         self.devices[device.name] = device

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -150,7 +150,7 @@ class Environment(object):
         elif isinstance(device, Motion):
             callback = self._motion_callback
             registry = self._motions
-        if isinstance(device, Maker):
+        elif isinstance(device, Maker):
         	callback = self._maker_callback
         	registry = self._makers
         else:

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -159,11 +159,7 @@ class Environment(object):
         registry[device.name] = device
         if self._with_subscribers:
             self.registry.register(device)
-            if isinstance(device, Maker):
-            	self.registry.on(device, 'sensorstate', 
-            	             device._update_state)
-            else:	
-                self.registry.on(device, 'BinaryState',
+            self.registry.on(device, 'BinaryState',
                              device._update_state)
         try:
             device.ping()

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -144,15 +144,15 @@ class Environment(object):
         self._process_device(device)
 
     def _process_device(self, device, cache=None):
-        if isinstance(device, Maker):
-            callback = self._maker_callback
-            registry = self._makers
-        elif isinstance(device, Switch):
+        if isinstance(device, Switch):
             callback = self._switch_callback
             registry = self._switches
         elif isinstance(device, Motion):
             callback = self._motion_callback
             registry = self._motions
+        elif isinstance(device, Maker):
+            callback = self._maker_callback
+            registry = self._makers
         else:
             return
         self.devices[device.name] = device

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -159,7 +159,11 @@ class Environment(object):
         registry[device.name] = device
         if self._with_subscribers:
             self.registry.register(device)
-            self.registry.on(device, 'BinaryState',
+            if isinstance(device, Maker):
+            	self.registry.on(device, 'sensorstate', 
+            	             device._update_state)
+            else:	
+                self.registry.on(device, 'BinaryState',
                              device._update_state)
         try:
             device.ping()

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -185,7 +185,7 @@ class Environment(object):
         return self._motions.keys()
         
     def list_makers(self):
-    	        """
+    	"""
         List makers discovered in the environment.
         """
         return self._makers.keys()

--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -33,7 +33,7 @@ class UnknownDevice(Exception):
 
 
 class Environment(object):
-    def __init__(self, switch_callback=_NOOP, motion_callback=_NOOP,
+    def __init__(self, switch_callback=_NOOP, motion_callback=_NOOP, maker_callback=_NOOP, 
                  with_discovery=True, with_subscribers=True, with_cache=None,
                  bind=None, config_filename=None):
         """
@@ -62,8 +62,10 @@ class Environment(object):
         self._with_subscribers = with_subscribers
         self._switch_callback = switch_callback
         self._motion_callback = motion_callback
+        self._maker_callback = maker_callback
         self._switches = {}
         self._motions = {}
+        self._makers = {}
         self.devices = {}
 
     def __iter__(self):
@@ -148,6 +150,9 @@ class Environment(object):
         elif isinstance(device, Motion):
             callback = self._motion_callback
             registry = self._motions
+        if isinstance(device, Maker):
+        	callback = self._maker_callback
+        	registry = self._makers
         else:
             return
         self.devices[device.name] = device
@@ -178,6 +183,12 @@ class Environment(object):
         List motions discovered in the environment.
         """
         return self._motions.keys()
+        
+    def list_makers(self):
+    	        """
+        List makers discovered in the environment.
+        """
+        return self._makers.keys()
 
     def get(self, name):
         alias = self._config.aliases.get(name)
@@ -208,6 +219,15 @@ class Environment(object):
         """
         try:
             return self._motions[name]
+        except KeyError:
+            raise UnknownDevice(name)
+
+    def get_maker(self, name):
+        """
+        Get a maker by name.
+        """
+        try:
+            return self._makers[name]
         except KeyError:
             raise UnknownDevice(name)
 

--- a/ouimeaux/subscribe.py
+++ b/ouimeaux/subscribe.py
@@ -8,6 +8,7 @@ from gevent.wsgi import WSGIServer
 
 from ouimeaux.utils import get_ip_address, requests_request
 from ouimeaux.device.insight import Insight
+from ouimeaux.device.maker import Maker
 from ouimeaux.signals import subscription
 
 
@@ -29,7 +30,10 @@ class SubscriptionRegistry(object):
         log.info("Subscribing to basic events from %r", device)
         # Provide a function to register a callback when the device changes
         # state
-        device.register_listener = partial(self.on, device, 'BinaryState')
+        if isinstance(device, Maker):
+            device.register_listener = partial(self.on, device, 'sensorstate')
+        else:
+            device.register_listener = partial(self.on, device, 'BinaryState')
         self._devices[device.host] = device
         self._resubscribe(device.basicevent.eventSubURL)
 

--- a/ouimeaux/subscribe.py
+++ b/ouimeaux/subscribe.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+\from collections import defaultdict
 import logging
 from xml.etree import cElementTree
 from functools import partial

--- a/ouimeaux/subscribe.py
+++ b/ouimeaux/subscribe.py
@@ -1,4 +1,4 @@
-\from collections import defaultdict
+from collections import defaultdict
 import logging
 from xml.etree import cElementTree
 from functools import partial

--- a/ouimeaux/subscribe.py
+++ b/ouimeaux/subscribe.py
@@ -30,10 +30,7 @@ class SubscriptionRegistry(object):
         log.info("Subscribing to basic events from %r", device)
         # Provide a function to register a callback when the device changes
         # state
-        if isinstance(device, Maker):
-            device.register_listener = partial(self.on, device, 'sensorstate')
-        else:
-            device.register_listener = partial(self.on, device, 'BinaryState')
+        device.register_listener = partial(self.on, device, 'BinaryState')
         self._devices[device.host] = device
         self._resubscribe(device.basicevent.eventSubURL)
 


### PR DESCRIPTION
Adds Wemo Maker CLI Functions:

usage: wemo maker device state
 Where state can alter or view the status of a Wemo Maker
     
     on, off, or toggle: Changes the state of the switch
     sensor: Displays the state of the sensor if present
     switch:  Displays the state of the Maker switch when it has been configured as persistent

In addition, list and status commands have been extended to display details about Wemo Makers
    ex:
monitor:~> wemo -v status
Switch: Kitchen Lights 	on
Switch: Garage Entry Lights 	off
Maker: Garage Door 	Momentary State: off
			                Sensor: Sensor triggered
