### PR TITLE
Insight doc: today_ontime should be today_on_time

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -169,7 +169,6 @@ exposed::
     insight.current_power
     insight.today_on_time
     insight.on_for
-    insight.in_standby_since
     insight.today_standby_time
 
 Device Cache

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -167,7 +167,7 @@ exposed::
 
     insight.today_kwh
     insight.current_power
-    insight.today_ontime
+    insight.today_on_time
     insight.on_for
     insight.in_standby_since
     insight.today_standby_time


### PR DESCRIPTION
There is a typo in the `Insight` section of the `Python API` section of the docs in `api.rst`. The command for seeing today's on time should be `today_on_time`, not `today_ontime`.