### PR TITLE
have server mode honor the --bind argument

### DIFF
--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -202,7 +202,7 @@ def clear(args):
 def server(args):
     from socketio.server import SocketIOServer
     from ouimeaux.server import app, initialize
-    initialize()
+    initialize(bind=getattr(args, 'bind', None))
     level = logging.INFO
     if getattr(args, 'debug', False):
         level = logging.DEBUG

--- a/ouimeaux/server/__init__.py
+++ b/ouimeaux/server/__init__.py
@@ -25,10 +25,10 @@ api = Api(app)
 ENV = None
 
 
-def initialize():
+def initialize(bind=None):
     global ENV
     if ENV is None:
-        ENV = Environment(with_cache=False)
+        ENV = Environment(with_cache=False, bind = bind)
         ENV.start()
         gevent.spawn(ENV.discover, 10)
 


### PR DESCRIPTION
this has the server mode honor the --bind argument for discovery, the same as with the other CLI modes.  my use case is that my Wemos are on a separate network and I have a dual-homed VM controlling them.