### PR TITLE
Fix for New Switch Firmware

### DIFF
--- a/ouimeaux/device/__init__.py
+++ b/ouimeaux/device/__init__.py
@@ -25,10 +25,11 @@ class Device(object):
         self.services = {}
         for svc in sl.service:
             svcname = svc.get_serviceType().split(':')[-2]
-            service = Service(svc, base_url)
-            service.eventSubURL = base_url + svc.get_eventSubURL()
-            self.services[svcname] = service
-            setattr(self, svcname, service)
+            if svcname != "deviceevent":
+                service = Service(svc, base_url)
+                service.eventSubURL = base_url + svc.get_eventSubURL()
+                self.services[svcname] = service
+                setattr(self, svcname, service)
 
     def _update_state(self, value):
         self._state = int(value)

--- a/ouimeaux/utils.py
+++ b/ouimeaux/utils.py
@@ -72,7 +72,7 @@ def retry_with_delay(f, delay=60):
     """
     @wraps(f)
     def inner(*args, **kwargs):
-        kwargs['timeout'] = 1
+        kwargs['timeout'] = 5
         remaining = get_retries() + 1
         while remaining:
             remaining -= 1


### PR DESCRIPTION
Directly in response to #78.

Might not be the best workaround as I don't fully understand what the "deviceevents" service does. However, disabling this service seems to patch the issue for now.

Also, a previous commit I made to bump up the response timeout is included to account for a response through the Link (bridge).