### PR TITLE
Fix Maker switch state

### DIFF
--- a/ouimeaux/device/__init__.py
+++ b/ouimeaux/device/__init__.py
@@ -25,11 +25,10 @@ class Device(object):
         self.services = {}
         for svc in sl.service:
             svcname = svc.get_serviceType().split(':')[-2]
-            if svcname != "deviceevent":
-                service = Service(svc, base_url)
-                service.eventSubURL = base_url + svc.get_eventSubURL()
-                self.services[svcname] = service
-                setattr(self, svcname, service)
+            service = Service(svc, base_url)
+            service.eventSubURL = base_url + svc.get_eventSubURL()
+            self.services[svcname] = service
+            setattr(self, svcname, service)
 
     def _update_state(self, value):
         self._state = int(value)

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -12,7 +12,7 @@ class Maker(Device):
         """
         Returns 0 if off and 1 if on.
         """
-        # The base implementation using GetBinaryState doesn't for for Maker (always returns 0).
+        # The base implementation using GetBinaryState doesn't work for Maker (always returns 0).
         # So pull the switch state from the atrributes instead
         if force_update or self._state is None:
             return(int(self.maker_attribs.get('switchstate',0)))

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -7,7 +7,17 @@ class Maker(Device):
 
     def __repr__(self):
         return '<WeMo Maker "{name}">'.format(name=self.name)
-        
+
+    def get_state(self, force_update=False):
+        """
+        Returns 0 if off and 1 if on.
+        """
+        # The base implementation using GetBinaryState doesn't for for Maker (always returns 0).
+        # So pull the switch state from the atrributes instead
+        if force_update or self._state is None:
+            return(int(self.maker_attribs.get('switchstate',0)))
+        return self._state
+
     def set_state(self, state):
         """
         Set the state of this device to on or off.
@@ -35,24 +45,31 @@ class Maker(Device):
         makerresp = makerresp.replace("&lt;","<")
         attributes = et.fromstring(makerresp)
         for attribute in attributes:
-            if attribute[0].text == "Sensor":
-            	sensorstate = attribute[1].text
+            if attribute[0].text == "Switch":
+              switchstate = attribute[1].text
+            elif attribute[0].text == "Sensor":
+              sensorstate = attribute[1].text
             elif attribute[0].text == "SwitchMode":
             	switchmode = attribute[1].text
             elif attribute[0].text == "SensorPresent":
             	hassensor = attribute[1].text
-        return { 'sensorstate' : int(sensorstate),
+        return { 'switchstate' : int(switchstate),
+             'sensorstate' : int(sensorstate),
         		 'switchmode' : int(switchmode),
         		 'hassensor' : int(hassensor)}
 
     @property
+    def switch_state(self):
+        return self.maker_attribs['switchstate']
+
+    @property
     def sensor_state(self):
         return self.maker_attribs['sensorstate']
-        
+
     @property
     def switch_mode(self):
     	return self.maker_attribs['switchmode']
-    
+
     @property
     def has_sensor(self):
     	return self.maker_attribs['hassensor']


### PR DESCRIPTION
My Wemo Makers don't return their state correctly - don't know if this has never worked - or was broken by some firmware update.

This PR changes Maker to get the switch state via attributes.

Closes https://github.com/iancmcc/ouimeaux/issues/98 and perhaps https://github.com/iancmcc/ouimeaux/issues/99