### PR TITLE
Fix maker handling in CLI

### DIFF
--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -192,6 +192,9 @@ Usage: wemo maker NAME (on|off|toggle|sensor|switch)"""
 
     def on_motion(maker):
         return
+    
+    def on_bridge(maker):
+        return
         
     def on_maker(maker):
         if matches(maker.name):
@@ -219,7 +222,7 @@ Usage: wemo maker NAME (on|off|toggle|sensor|switch)"""
                 getattr(maker, state)()
             sys.exit(0)
             
-    scan(args, on_switch, on_motion, on_maker)
+    scan(args, on_switch, on_motion, on_bridge, on_maker)
     # If we got here, we didn't find anything
     print "No device found with that name."
     sys.exit(1)


### PR DESCRIPTION
Maker handler was being passed to scan as bridge handler. Added no-op bridge handler similar to existing switch and motion handlers.