### PR TITLE
Fixed #63

### DIFF
--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -80,8 +80,7 @@ class Environment(object):
             # Start the server to listen to new devices
             self.upnp.server.set_spawn(2)
             self.upnp.server.start()
-
-        if self._with_subscribers:
+        elif self._with_subscribers:
             # Start the server to listen to events
             self.registry.server.set_spawn(2)
             self.registry.server.start()


### PR DESCRIPTION
The problem was the discovery and signal option was defaulting to true, instead of booting up BOTH it only boots the first if it can and then the second if it cant. 