### PR TITLE
fixed iancmcc/ouimeaux#119 

### DIFF
--- a/ouimeaux/environment.py
+++ b/ouimeaux/environment.py
@@ -80,7 +80,7 @@ class Environment(object):
             # Start the server to listen to new devices
             self.upnp.server.set_spawn(2)
             self.upnp.server.start()
-        elif self._with_subscribers:
+        if self._with_subscribers:
             # Start the server to listen to events
             self.registry.server.set_spawn(2)
             self.registry.server.start()


### PR DESCRIPTION
discovery and notification servers should be able to run together
this was originally changed to `elif` in #63, but I think it should still be fine since the notification server now listens on a random port.