### PR TITLE
Fix for "TypeError: connect() got an unexpected keyword argument 'unique'"

### DIFF
--- a/ouimeaux/server/__init__.py
+++ b/ouimeaux/server/__init__.py
@@ -131,7 +131,6 @@ class SocketNamespace(BaseNamespace):
 
     def on_join(self, data):
         statechange.connect(self.update_state,
-                            unique=False,
                             dispatch_uid=id(self))
         for device in ENV:
             self.update_state(device)


### PR DESCRIPTION
This pull request fixes the following error:

```
...
  File "/home/jansel/ouimeaux/venv/local/lib/python2.7/site-packages/socketio/namespace.py", line 282, in call_method
    return method(*args)
  File "/home/jansel/ouimeaux/ouimeaux/server/__init__.py", line 135, in on_join
    dispatch_uid=id(self))
TypeError: connect() got an unexpected keyword argument 'unique'
```

Which I experienced with the following package versions (latest versions at time of writing):

```
aniso8601==1.1.0
anyjson==0.3.3
click==6.6
Flask==0.11.1
Flask-RESTful==0.3.5
future==0.15.2
gevent==1.1.2
gevent-socketio==0.3.6
gevent-websocket==0.9.5
greenlet==0.4.10
itsdangerous==0.24
Jinja2==2.8
MarkupSafe==0.23
-e git+https://github.com/iancmcc/ouimeaux.git@5fc26748690c18b6e17ea1661898b2f03bbd5beb#egg=ouimeaux
python-dateutil==2.5.3
pytz==2016.6.1
PyYAML==3.12
requests==2.11.1
six==1.10.0
Werkzeug==0.11.11
```
