### PR TITLE
added support for CORS

### DIFF
--- a/ouimeaux/server/__init__.py
+++ b/ouimeaux/server/__init__.py
@@ -7,6 +7,9 @@ from flask import send_file, make_response, abort
 from flask.ext.restful import reqparse, abort, Api, Resource
 from flask.ext.basicauth import BasicAuth
 
+# add support for CORS - https://flask-cors.readthedocs.io/en/latest/
+from flask_cors import CORS, cross_origin
+
 
 from ouimeaux.signals import statechange
 from ouimeaux.device.switch import Switch
@@ -22,6 +25,10 @@ here = lambda *x: os.path.join(os.path.dirname(__file__), *x)
 
 app = Flask(__name__)
 api = Api(app)
+
+#add support for CORS
+CORS(app)
+
 
 ENV = None
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             'wemo = ouimeaux.cli:wemo'
         ]
     },
+    # added CORS as dependency
     extras_require = {
         'server':  [
             "flask-restful",

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             "flask-restful",
             "flask-basicauth",
             "gevent-socketio",
+            "flask-cors",
         ],
     },
     test_suite='tests',


### PR DESCRIPTION
Added support for CORS to enbles API calls cross domain.

details here  - https://flask-cors.readthedocs.io/en/latest/

Dependency needs to be added to package or install instructions to add 
`$ pip install -U flask-cors`