### PR TITLE
Fix issue #132 - light state not working since mid 2016 firmware update

### DIFF
--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -106,19 +106,21 @@ Usage: wemo light NAME (on|off|toggle|status)""")
                 elif args.state == "status":
                     print(bridge.light_get_state(bridge.Lights[light]))
                 else:
-                    if args.dim == None and args.state == "on":
-                        dim = bridge.light_get_state(bridge.Lights[light]).get('dim')
-                        state = 1
-                    elif args.state == "off":
+                    if args.state == "on":
+                        if args.dim is not None:
+                            if args.dim <= 255 and args.dim >= 0:
+                                dim = args.dim
+                                state = None
+                            else:
+                                print("""Invalid dim specified.
+Dim must be between 0 and 255""")
+                                sys.exit(1)
+                        else:
+                            dim = None
+                            state = 1
+                    else:
                         dim = None
                         state = 0
-                    elif args.dim <= 255 and args.dim >= 0:
-                        dim = args.dim
-                        state = 1
-                    else:
-                        print("""Invalid dim specified.
-Dim must be between 0 and 255""")
-                        sys.exit(1)
                     bridge.light_set_state(bridge.Lights[light], state=state, dim=dim)
                 if args.name != 'all':
                     sys.exit(0)

--- a/ouimeaux/device/bridge.py
+++ b/ouimeaux/device/bridge.py
@@ -88,13 +88,15 @@ class Bridge(Device):
             'dim' : dim
         }
 
-    def light_set_state(self, light, state=None, dim=None):
-        if state == None:
-            state = self.light_get_state(light).get('state')
-        if dim == None:
-            dim = self.light_get_state(light).get('dim')
+    # Specify either a state or dim - not both. When specifying dim you can also specify a transition duration to dim across.
+    # This resolves issues that appear to have been caused by a firmware update ~ mid 2016.
+    # Details at https://github.com/iancmcc/ouimeaux/issues/132.
+    def light_set_state(self, light, state=None, dim=None, transition_duration=0):
+        if not state == None:
+            sendState = '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID available=&quot;YES&quot;&gt;{devID}&lt;/DeviceID&gt;&lt;CapabilityID&gt;10006&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;{state}&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;'.format(devID=self.light_get_id(light),state=state)
+        elif not dim == None:
+            sendState = '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID available=&quot;YES&quot;&gt;{devID}&lt;/DeviceID&gt;&lt;CapabilityID&gt;10008&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;{dim}:{duration}&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;'.format(devID=self.light_get_id(light),dim=dim,duration=transition_duration)
 
-        sendState = '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;DeviceStatus&gt;&lt;IsGroupAction&gt;NO&lt;/IsGroupAction&gt;&lt;DeviceID available=&quot;YES&quot;&gt;{devID}&lt;/DeviceID&gt;&lt;CapabilityID&gt;10006&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;{state}&lt;/CapabilityValue&gt;&lt;CapabilityID&gt;10008&lt;/CapabilityID&gt;&lt;CapabilityValue&gt;{dim}&lt;/CapabilityValue&gt;&lt;/DeviceStatus&gt;'.format(devID=self.light_get_id(light),state=state,dim=dim)
         return self.bridge.SetDeviceStatus(DeviceStatusList=sendState)
 
     def group_set_state(self, group, state=None, dim=None):


### PR DESCRIPTION
Fixes issue #132 where light state is not getting set. You can no longer pass both the state and dim value - need to pass either one. Now light_set_state call sets each one  (CapabilityID=10006 AND CapabilityID=10008). CLI did not need to change - just set correct values based on requested change.