### PR TITLE
Specify the Loader when calling yaml.load()

### DIFF
--- a/ouimeaux/config.py
+++ b/ouimeaux/config.py
@@ -47,7 +47,7 @@ aliases:
 # auth: admin:password
 """)
         with open(filename, 'r') as cfg:
-            self._parsed = yaml.load(cfg)
+            self._parsed = yaml.load(cfg, Loader=yaml.FullLoader)
 
     @property
     def aliases(self):


### PR DESCRIPTION
fixes #189 