### PR TITLE
Show the help message when no action is specified

### DIFF
--- a/ouimeaux/cli.py
+++ b/ouimeaux/cli.py
@@ -371,4 +371,7 @@ def wemo():
     if getattr(args, 'debug', False):
         logging.basicConfig(level=logging.DEBUG)
 
-    args.func(args)
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help(sys.stderr)


### PR DESCRIPTION
Right now when one runs the `wemo` command without arguments it throws an error.

```
Traceback (most recent call last):
  File "/home/epoulin/.local/share/pyenv/versions/shell/bin/wemo", line 10, in <module>
    sys.exit(wemo())
  File "/home/epoulin/.local/share/pyenv/versions/3.7.2/envs/shell/lib/python3.7/site-packages/ouimeaux/cli.py", line 375, in wemo
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

This PR changes it so that the usage message is printed instead.