### PR TITLE
replace cElementTree with ElementTree

### DIFF
--- a/ouimeaux/device/api/service.py
+++ b/ouimeaux/device/api/service.py
@@ -1,5 +1,5 @@
 import logging
-from xml.etree import cElementTree as et
+from xml.etree import ElementTree as et
 
 from ...utils import requests_get, requests_post
 from .xsd import service as serviceParser

--- a/ouimeaux/device/bridge.py
+++ b/ouimeaux/device/bridge.py
@@ -1,6 +1,6 @@
 from ouimeaux.device import Device
 
-from xml.etree import cElementTree as et
+from xml.etree import ElementTree as et
 
 
 class Bridge(Device):

--- a/ouimeaux/device/maker.py
+++ b/ouimeaux/device/maker.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from ouimeaux.device import Device
-from xml.etree import cElementTree as et
+from xml.etree import ElementTree as et
 
 
 class Maker(Device):

--- a/ouimeaux/subscribe.py
+++ b/ouimeaux/subscribe.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import logging
-from xml.etree import cElementTree
+from xml.etree import ElementTree
 from functools import partial
 
 import gevent
@@ -69,7 +69,7 @@ class SubscriptionRegistry(object):
             data = environ['wsgi.input'].read()
             # trim garbage from end, if any
             data = data.split("\n\n")[0]
-            doc = cElementTree.fromstring(data)
+            doc = ElementTree.fromstring(data)
             for propnode in doc.findall('./{0}property'.format(NS)):
                 for property_ in propnode.getchildren():
                     text = property_.text


### PR DESCRIPTION
fixes #203 

This fixes the most immediate need by replacing cElementTree with ElementTree in these files:
```
ouimeaux/device/api/service.py
ouimeaux/device/maker.py
ouimeaux/device/bridge.py
ouimeaux/subscribe.py
```

However, a better fix might be to implement a series of try/except, similar to what has already been done here:
https://github.com/iancmcc/ouimeaux/blob/develop/ouimeaux/device/api/xsd/service.py#L27
https://github.com/iancmcc/ouimeaux/blob/develop/ouimeaux/device/api/xsd/device.py#L27

I'll leave that up to the author to decide.