### PR TITLE
move StateChange subclass to signals.py

### DIFF
--- a/ouimeaux/pysignals/dispatcher.py
+++ b/ouimeaux/pysignals/dispatcher.py
@@ -317,51 +317,6 @@ class Signal(object):
             return func
         return _decorator
 
-
-class StateChange( Signal ):
-
-    def __init__(self, providing_args=None):
-        super(StateChange, self).__init__(providing_args)
-        self.sender_status = {}
-
-    def send(self, sender, **named):
-        """
-        Send signal from sender to all connected receivers *only if* the signal's
-        contents has changed.
-
-        If any receiver raises an error, the error propagates back through send,
-        terminating the dispatch loop, so it is quite possible to not have all
-        receivers called if a raises an error.
-
-        Arguments:
-
-            sender
-                The sender of the signal Either a specific object or None.
-
-            named
-                Named arguments which will be passed to receivers.
-
-        Returns a list of tuple pairs [(receiver, response), ... ].
-        """
-        responses = []
-        if not self.receivers:
-            return responses
-
-        sender_id = _make_id(sender)
-        if sender_id not in self.sender_status:
-            self.sender_status[sender_id] = {}
-
-        if self.sender_status[sender_id] == named:
-            return responses
-
-        self.sender_status[sender_id] = named
-
-        for receiver in self._live_receivers(sender_id):
-            response = receiver(signal=self, sender=sender, **named)
-            responses.append((receiver, response))
-        return responses
-
-
 def receiver(signal, **kwargs):
     """
     A decorator for connecting receivers to signals. Used by passing in the

--- a/ouimeaux/signals.py
+++ b/ouimeaux/signals.py
@@ -1,4 +1,4 @@
-from ouimeaux.pysignals import Signal, StateChange, receiver
+from ouimeaux.pysignals import Signal, receiver
 
 # Work around a bug in pysignals when in the interactive interpreter
 import sys
@@ -6,6 +6,43 @@ _main = sys.modules.get('__main__')
 if _main:
     _main.__file__ = "__main__.py"
 
+class StateChange( Signal ):
+
+    def __init__(self, providing_args=None):
+        super(StateChange, self).__init__(providing_args)
+        self.sender_status = {}
+
+    def send(self, sender, **named):
+        """
+        Send signal from sender to all connected receivers *only if* the signal's
+        contents has changed.
+        If any receiver raises an error, the error propagates back through send,
+        terminating the dispatch loop, so it is quite possible to not have all
+        receivers called if a raises an error.
+        Arguments:
+            sender
+                The sender of the signal Either a specific object or None.
+            named
+                Named arguments which will be passed to receivers.
+        Returns a list of tuple pairs [(receiver, response), ... ].
+        """
+        responses = []
+        if not self.receivers:
+            return responses
+
+        sender_id = _make_id(sender)
+        if sender_id not in self.sender_status:
+            self.sender_status[sender_id] = {}
+
+        if self.sender_status[sender_id] == named:
+            return responses
+
+        self.sender_status[sender_id] = named
+
+        for receiver in self._live_receivers(sender_id):
+            response = receiver(signal=self, sender=sender, **named)
+            responses.append((receiver, response))
+        return responses
 
 # Fires when a device responds to a broadcast 
 discovered = Signal(providing_args=["address", "headers"])


### PR DESCRIPTION
fixes #205 

This is one way to resolve the packaging dilemma described in #205.

This PR attempts to strike a compromise by leaving the bundled pysignals library in place (done by design as as result of #32), while at the same time making it easier for a packager to unbundle pysignals in favor of a pysignals package from the target distro.

Feedback is welcome here. 